### PR TITLE
Update kamon dependencies versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,13 +45,10 @@ lazy val root = (project in file("."))
       "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion % Test,
 
-      "io.kamon" %% "kamon-bundle" % "2.0.0",
-      "io.kamon" %% "kamon-akka" % "2.1.0",
-      "io.kamon" %% "kamon-akka-http" % "2.1.0",
+      "io.kamon" %% "kamon-bundle" % "2.1.0",
+      "io.kamon" %% "kamon-logback" % "2.1.0",
       "io.kamon" %% "kamon-prometheus" % "2.1.0",
       "io.kamon" %% "kamon-zipkin" % "1.0.0",
-      "io.kamon" %% "kamon-logback" % "2.1.0",
-      "io.kamon" %% "kamon-system-metrics" % "2.1.0"
     )
   )
 


### PR DESCRIPTION
- There is a version mismatch between kamon-bundle and kamon-akka, kamon-akka-http, kamon-logback. This can cause ClassCastException depending on the class loading timing.
- If kamon-bundle is included, dependencies on kamon-akka, kamon-akka-http, and kamon-system-metrics are unnecessary and should be removed.